### PR TITLE
nova-extension-schema: allow null as value of configItem enum tuples

### DIFF
--- a/json.novaextension/nova-extension-schema.json
+++ b/json.novaextension/nova-extension-schema.json
@@ -443,7 +443,10 @@
               { "type": "string" },
               {
                 "type": "array",
-                "items": [{ "type": "string" }, { "type": "string" }]
+                "items": [
+                  { "type": ["string", "null"] },
+                  { "type": "string" }
+                ]
               }
             ]
           }

--- a/json.novaextension/nova-extension-schema.json
+++ b/json.novaextension/nova-extension-schema.json
@@ -443,10 +443,7 @@
               { "type": "string" },
               {
                 "type": "array",
-                "items": [
-                  { "type": ["string", "null"] },
-                  { "type": "string" }
-                ]
+                "items": [{ "type": ["string", "null"] }, { "type": "string" }]
               }
             ]
           }


### PR DESCRIPTION
Turns out the `value` of an enum configItem when using the `[value, display value]` tuple form is nullable. This is undocumented, but has been successfully used by a few extensions to signal an `off` value (among them my own). 

On a related note, I’ve tried to test if other types might work too, but could not get the `nova.config.onDidChange` event to notify me of anything (its seems to swallow `console` calls). I’ll gladly accept any suggestion you might happen to have …